### PR TITLE
[fix][CTS]修改了kernel参数对齐的方式

### DIFF
--- a/lib/CL/devices/ventus/pocl_ventus.cc
+++ b/lib/CL/devices/ventus/pocl_ventus.cc
@@ -601,7 +601,7 @@ step5 make a writefile for chisel
        || (meta->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)) {
         abuf_size += 4;
       } else {
-        abuf_size += al->size;
+        abuf_size = pocl_align_value(abuf_size+al->size, pocl_size_ceil2_64(std::max(al->size, (uint64_t)4)));
       }
     }
 
@@ -617,12 +617,13 @@ step5 make a writefile for chisel
       if ((meta->arg_info[i].type == POCL_ARG_TYPE_POINTER)
        || (meta->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
        || (meta->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)) {
-       // memcpy(abuf_args_data+abuf_args_p,((cl_mem)(al->value))->device_ptrs->mem_ptr,4);
-          memcpy(abuf_args_data+abuf_args_p,arguments[i],4);
-        abuf_args_p+=4;
+        size_t alloc_p = pocl_align_value(abuf_args_p, 4);
+        memcpy(abuf_args_data+alloc_p,arguments[i],4);
+        abuf_args_p=alloc_p + 4;
       } else {
-        memcpy(abuf_args_data+abuf_args_p,al->value,al->size);
-        abuf_args_p+=al->size;
+        size_t alloc_p = pocl_align_value(abuf_args_p, pocl_size_ceil2_64(std::max(al->size, (uint64_t)4)));
+        memcpy(abuf_args_data+alloc_p,al->value,al->size);
+        abuf_args_p = alloc_p + al->size;
       }
     }
     POCL_MSG_PRINT_VENTUS("Allocating kernel arg buffer entry:\n");

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -65,6 +65,7 @@ void bzero_s (void *v, size_t n);
 /* Finds the next highest power of two of the given value. */
 POCL_EXPORT
 size_t pocl_size_ceil2 (size_t x);
+POCL_EXPORT
 uint64_t pocl_size_ceil2_64 (uint64_t x);
 POCL_EXPORT
 size_t pocl_align_value (size_t value, size_t alignment);


### PR DESCRIPTION
#47 
对于小于4byte的变量对齐到4byte，大于4byte的变量对齐到下一个大于该变量大小的2的幂大小

如果一个变量大小为6B，则按8B对齐
如果一个变量大小为12B，则按16B对齐
![image](https://github.com/THU-DSP-LAB/pocl/assets/37099022/eecaf355-7a21-46a2-89c6-eefaa2216c25)
