### PR TITLE
[Ventus][Kernel] Fix the loss of the kernel name

### DIFF
--- a/lib/CL/devices/ventus/pocl_ventus.cc
+++ b/lib/CL/devices/ventus/pocl_ventus.cc
@@ -1436,7 +1436,9 @@ int pocl_ventus_post_build_program (cl_program program, cl_uint device_i) {
 	for(int i = 0; ventus_other_compile_flags[i] != NULL; i++) {
 		ss_cmd << ventus_other_compile_flags[i];
 	}
-  ss_cmd << "-Wl,--init=" << program->kernel_meta->name << " ";
+  if(program->kernel_meta) {
+    ss_cmd << "-Wl,--init=" << program->kernel_meta->name << " ";
+  }
 #ifdef POCL_DEBUG_FLAG_GENERAL
 	ss_cmd << " -w ";
 #endif


### PR DESCRIPTION
Solve the problem of missing names when compiling the kernel without setting up kernel metadata.