### PR TITLE
[VENTUS][feat] Enable OpenCL 2.0 generic address space

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -505,6 +505,12 @@ int pocl_llvm_build_program(cl_program program,
 
   // the per-file types don't seem to override this
   la->OpenCLVersion = cl_std_i;
+
+  // Enable OpenCL generic address space for OpenCL 2.0 and later
+  if (la->OpenCL && cl_std_i >= 200) {
+    la->OpenCLGenericAddressSpace = true;
+  }
+
   la->FakeAddressSpaceMap = false;
   la->Blocks = true; //-fblocks
   la->MathErrno = false; // -fno-math-errno


### PR DESCRIPTION
1. Background
```
wenhu@wenhu:~/work/ventus/opencl-test/OpenCL-CTS/build/test_conformance/generic_address_space$   
./test_generic_address_space  function_to_address_space

 Initializing random seed to 0.
Requesting Default device based on command line for platform index 0 and device index 0
[INFO]: [HW DRIVER] in [FILE] ventus.cpp,[LINE]25,[fn] vt_dev_open: vt_dev_open : hello world from ventus.cpp
spike device initialize: allocating local memory: to allocate at 0x70000000 with 268435456 bytes 
spike device initialize: allocating pc source memory: to allocate at 0x80000000 with 268435456 bytes 
Compute Device Name = Ventus GPGPU device, Compute Device Vendor = THU, Compute Device Version = OpenCL 2.0 PoCL HSTR: THU-ventus-GPGPU
, CL C Version = OpenCL C 2.0 PoCL
Supports single precision denormals: YES
sizeof( void*) = 8  (host)
sizeof( void*) = 4  (device)
function_to_address_space...
Executing subcase #1 out of 1
### options: -DPOCL_DEVICE_ADDRESS_BITS=32 -D__USE_CLANG_OPENCL_C_H -xcl -Dinline= -I. -cl-kernel-arg-info -cl-std=CL2.0 -D__ENDIAN_LITTLE__=1 -DCL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE=0 -D__OPENCL_VERSION__=200 -D__OPENCL_C_VERSION__=200 -Dcl_khr_fp64=1 -D__opencl_c_generic_address_space=1 -D__opencl_c_named_address_space_builtins=1 -cl-ext=-all,+cl_khr_fp64,+__opencl_c_generic_address_space,+__opencl_c_named_address_space_builtins -fno-builtin -triple=riscv32 -target-cpu ventus-gpgpu user_options: -cl-std=CL2.0
### Triple: riscv32, CPU: ventus-gpgpu
6 errors generated.
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:7:9: use of undeclared identifier 'to_global'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:9:9: use of undeclared identifier 'to_local'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:11:9: use of undeclared identifier 'to_global'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:13:9: use of undeclared identifier 'to_local'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:15:9: use of undeclared identifier 'to_private'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:39:35: passing '__global int *__private' to parameter of type '__private int *' changes address space of pointer

ERROR: clBuildProgram failed! (CL_BUILD_PROGRAM_FAILURE from /home/wenhu/work/ventus/opencl-test/OpenCL-CTS/test_common/harness/kernelHelpers.cpp:844)
Build options:  -cl-std=CL2.0
Original source is: ------------


__global int gint = 1;
__global uchar guchar = 3;

bool helperFunction(int *gintp, float *lfloatp, uchar *gucharp, ushort *lushortp, long *plongp) {
    if (to_global(gintp) == NULL)
        return false;
    if (to_local(lfloatp) == NULL)
        return false;
    if (to_global(gucharp) == NULL)
        return false;
    if (to_local(lushortp) == NULL)
        return false;
    if (to_private(plongp) == NULL)
        return false;

    if (*gintp != 1 || *lfloatp != 2.0f || *gucharp != 3 || *lushortp != 4 || *plongp != 5)
        return false;

    return true;
}

__kernel void testKernel(__global uint *results) {
    uint tid = get_global_id(0);

    __local float lfloat;
    lfloat = 2.0f;
    __local ushort lushort;
    lushort = 4;
    long plong = 5;

    __global int *gintp = &gint;
    __local float *lfloatp = &lfloat;
    __global uchar *gucharp = &guchar;
    __local ushort *lushortp = &lushort;
    __private long *plongp = &plong;

    results[tid] = helperFunction(gintp, lfloatp, gucharp, lushortp, plongp);
}
Build not successful for device "Ventus GPGPU device", status: CL_BUILD_ERROR
Build log for device "Ventus GPGPU device" is: ------------
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:7:9: use of undeclared identifier 'to_global'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:9:9: use of undeclared identifier 'to_local'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:11:9: use of undeclared identifier 'to_global'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:13:9: use of undeclared identifier 'to_local'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:15:9: use of undeclared identifier 'to_private'
error: /home/wenhu/.cache/pocl/kcache/tempfile_jpMmwa.cl:39:35: passing '__global int *__private' to parameter of type '__private int *' changes address space of pointer
Device Ventus GPGPU device failed to build the program


----------
create_single_kernel_helper failedfunction_to_address_space FAILED
PASSED sub-test.
FAILED test.
```

2. Problem
OpenCL CTS tests were failing when using to_global(), to_local(), and to_private() functions with -cl-std=CL2.0, while standalone clang compilation worked fine.

3. Root Cause
PoCL's compilation flow has a design issue:
setLangDefaults() is called with hardcoded lang_opencl12
This sets OpenCLGenericAddressSpace = false (OpenCL 1.2 behavior)
Then OpenCLVersion is manually overridden to user's version (e.g., 200 for CL2.0)
But language features remain at OpenCL 1.2 level, causing feature/version mismatch

4. Solution
Manually enable OpenCL 2.0+ features after version override:
OpenCLGenericAddressSpace = true for cl_std_i >= 200
Conservative approach: minimal changes, maintains backward compatibility