### PR TITLE
Fix/ventus uninit issue

### DIFF
--- a/lib/CL/devices/ventus/pocl_ventus.cc
+++ b/lib/CL/devices/ventus/pocl_ventus.cc
@@ -129,7 +129,7 @@ pocl_ventus_init_device_ops(struct pocl_device_ops *ops)
   ops->probe = pocl_ventus_probe;
 
   ops->uninit = pocl_ventus_uninit;
-  ops->reinit = NULL;
+  ops->reinit = pocl_ventus_reinit;
   ops->init = pocl_ventus_init;
 
   ops->alloc_mem_obj = pocl_ventus_alloc_mem_obj;
@@ -988,6 +988,13 @@ pocl_ventus_uninit (unsigned j, cl_device_id device)
   device->data = NULL;
 
   return CL_SUCCESS;
+}
+
+cl_int
+pocl_ventus_reinit (unsigned j, cl_device_id device)
+{
+  // Simple reinit implementation for ventus device
+  return pocl_ventus_init(j, device, NULL);
 }
 
 

--- a/lib/CL/devices/ventus/pocl_ventus.h
+++ b/lib/CL/devices/ventus/pocl_ventus.h
@@ -66,6 +66,7 @@ unsigned int pocl_ventus_probe(struct pocl_device_ops *ops);
 cl_int pocl_ventus_init (unsigned j, cl_device_id dev, const char* parameters);
 void pocl_ventus_run (void *data, _cl_command_node *cmd);
 cl_int pocl_ventus_uninit (unsigned j, cl_device_id device);
+cl_int pocl_ventus_reinit (unsigned j, cl_device_id device);
 void ventus_command_scheduler (struct vt_device_data_t *d);
 void pocl_ventus_submit (_cl_command_node *node, cl_command_queue cq);
 void pocl_ventus_flush (cl_device_id device, cl_command_queue cq);

--- a/ventus_fix_changes.md
+++ b/ventus_fix_changes.md
@@ -1,0 +1,24 @@
+# Ventus Device Uninit Fix
+
+## Problem
+- pocl_ventus_uninit was not being called
+- vt_dev_close was never executed
+- Root cause: ops->reinit was NULL, causing skip in pocl_uninit_devices
+
+## Solution
+- Added pocl_ventus_reinit function implementation
+- Updated ops->reinit = pocl_ventus_reinit
+- Added function declaration in header file
+
+## Files Modified
+1. pocl/lib/CL/devices/ventus/pocl_ventus.cc
+   - Line 132: Changed ops->reinit from NULL to pocl_ventus_reinit
+   - Added pocl_ventus_reinit function implementation after line 990
+
+2. pocl/lib/CL/devices/ventus/pocl_ventus.h
+   - Added pocl_ventus_reinit function declaration
+
+## Testing
+- Set POCL_ENABLE_UNINIT=1
+- Use GDB to verify pocl_ventus_uninit is called
+- Confirm vt_dev_close is executed


### PR DESCRIPTION
## Problem
- pocl_ventus_uninit was not being called
- vt_dev_close was never executed
- Root cause: ops->reinit was NULL, causing skip in pocl_uninit_devices

## Solution
- Added pocl_ventus_reinit function implementation
- Set ops->reinit to pocl_ventus_reinit (was previously NULL)
- Declared pocl_ventus_reinit in header file

## Files Modified
- pocl/lib/CL/devices/ventus/pocl_ventus.cc
- pocl/lib/CL/devices/ventus/pocl_ventus.h

## Testing
- Set POCL_ENABLE_UNINIT=1
- Used GDB to verify pocl_ventus_uninit is called
- Confirmed vt_dev_close is executed