### PR TITLE
fix num_partition_properties

### DIFF
--- a/lib/CL/devices/ventus/pocl_ventus.cc
+++ b/lib/CL/devices/ventus/pocl_ventus.cc
@@ -312,8 +312,8 @@ pocl_ventus_init (unsigned j, cl_device_id dev, const char* parameters)
   dev->device_alloca_locals = 1; //
 
   // Doesn't support partition
-  dev->max_sub_devices = 1;
-  dev->num_partition_properties = 1;
+  dev->max_sub_devices = 0;
+  dev->num_partition_properties = 0;
   dev->num_partition_types = 0;
   dev->partition_type = NULL;
 


### PR DESCRIPTION
+ Comment claims no support for partitions, but `dev->num_partition_properties = 1` implies `dev->partition_properties` should be populated. This causes a segfault when running `clinfo`, which tries to read one element from `partition_properties`. Fix by setting `num_partition_properties = 0` to align with comment, and adjust `dev->max_sub_devices` to match.