### PR TITLE
ventus: classify private data store allocations

### DIFF
--- a/lib/CL/devices/ventus/pocl_ventus.cc
+++ b/lib/CL/devices/ventus/pocl_ventus.cc
@@ -1140,7 +1140,8 @@ step5 make a writefile for chisel
   uint64_t pds_dev_mem_addr = 0;
   if (pds_src_size > 0) {
     POCL_MSG_PRINT_VENTUS("Preparing private memory of ventus:\n");
-    err = vt_buf_alloc(d->vt_device, pds_src_size, &pds_dev_mem_addr,0,0,0);
+    err = vt_buf_alloc(d->vt_device, pds_src_size, &pds_dev_mem_addr,
+                       VT_BUFFER_TYPE_PDS, 0, 0);
     if (err != 0) {
       abort();
     }


### PR DESCRIPTION
## Summary
- mark Ventus private data store allocations with `VT_BUFFER_TYPE_PDS`
- allow the RTL PMEM backend to distinguish PDS/private-memory pages from general device buffers and true out-of-bounds accesses

## Verification
- clean Debug Ventus PoCL build against ventus-driver `114ff512b1d067ab9b6e3fd7d249d22d163c0443`
- built `pocl-devices-ventus` successfully
- representative PMEM region tests pass in ventus-gpgpu